### PR TITLE
implement relative precision mode

### DIFF
--- a/src/Filter/PrecisionControl/PrecisionControl.cs
+++ b/src/Filter/PrecisionControl/PrecisionControl.cs
@@ -4,6 +4,7 @@ using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Attributes;
 using OpenTabletDriver.Plugin.Output;
 using OpenTabletDriver.Plugin.Tablet;
+using OpenTabletDriver.Plugin.Timing;
 
 namespace VoiDPlugins.Filter
 {
@@ -12,12 +13,17 @@ namespace VoiDPlugins.Filter
     {
         internal static Vector2 StartingPoint;
         internal static bool IsActive { set; get; }
+        internal static bool IsRelative { set; get; }
         internal static bool SetPosition { set; get; }
 
         public static string[] ValidModes => new[] { "Toggle", "Hold" };
+        public static string[] ValidRelativeModes => new[] { "Absolute", "Relative" };
 
         [Property("Mode"), PropertyValidated(nameof(ValidModes))]
         public string? Mode { set; get; }
+
+        [Property("Relative Mode"), PropertyValidated(nameof(ValidRelativeModes))]
+        public string? RelativeMode { set; get; }
 
         public void Press(TabletReference tablet, IDeviceReport report)
         {
@@ -25,6 +31,9 @@ namespace VoiDPlugins.Filter
                 IsActive = !IsActive;
             else if (Mode == "Hold")
                 IsActive = true;
+
+            IsRelative = (RelativeMode == "Relative");
+
 
             SetPosition = true;
         }
@@ -41,10 +50,23 @@ namespace VoiDPlugins.Filter
     {
         public event Action<IDeviceReport>? Emit;
 
+        private readonly HPETDeltaStopwatch _stopwatch = new HPETDeltaStopwatch();
+
         [SliderProperty("Precision Multiplier", 0.0f, 10f, 0.3f), DefaultPropertyValue(0.3f)]
         public float Scale { get; set; }
 
+        [SliderProperty("Timeout", 100f, 1000f, 1f), DefaultPropertyValue(50), Unit("ms")]
+        [ToolTip("Time period after which the position is reset in relative mode.")]
+        public double Timeout
+        {
+            get { return timeout.TotalMilliseconds; }
+            set { timeout = TimeSpan.FromMilliseconds(value); }
+        }
+        private TimeSpan timeout;
+
         public PipelinePosition Position => PipelinePosition.PostTransform;
+        internal static Vector2 LastPosition;
+        internal static Vector2 NewZero;
 
         public void Consume(IDeviceReport value)
         {
@@ -53,14 +75,29 @@ namespace VoiDPlugins.Filter
                 if (PrecisionControlBinding.SetPosition)
                 {
                     PrecisionControlBinding.StartingPoint = report.Position;
+                    NewZero = report.Position;
                     PrecisionControlBinding.SetPosition = false;
+                }
+
+                if (PrecisionControlBinding.IsRelative)
+                {
+                    var deltaTime = _stopwatch.Restart();
+
+                    if (deltaTime > timeout) {
+                        PrecisionControlBinding.StartingPoint = LastPosition;
+                        NewZero = report.Position;
+                    }
                 }
 
                 if (PrecisionControlBinding.IsActive)
                 {
-                    var delta = (report.Position - PrecisionControlBinding.StartingPoint) * Scale;
+                    var relativeTo = PrecisionControlBinding.IsRelative ? NewZero : PrecisionControlBinding.StartingPoint;
+                    var delta = (report.Position - relativeTo) * Scale;
                     report.Position = PrecisionControlBinding.StartingPoint + delta;
                 }
+
+                LastPosition = report.Position;
+
                 value = report;
             }
 

--- a/src/Filter/PrecisionControl/PrecisionControl.cs
+++ b/src/Filter/PrecisionControl/PrecisionControl.cs
@@ -15,6 +15,7 @@ namespace VoiDPlugins.Filter
         internal static bool IsActive { set; get; }
         internal static bool IsRelative { set; get; }
         internal static bool SetPosition { set; get; }
+        internal static float CurrentScale { set; get; }
 
         public static string[] ValidModes => new[] { "Toggle", "Hold" };
         public static string[] ValidRelativeModes => new[] { "Absolute", "Relative" };
@@ -24,6 +25,9 @@ namespace VoiDPlugins.Filter
 
         [Property("Relative Mode"), PropertyValidated(nameof(ValidRelativeModes))]
         public string? RelativeMode { set; get; }
+
+        [SliderProperty("Precision Multiplier", 0.0f, 10f, 0.3f), DefaultPropertyValue(0.3f)]
+        public float Scale { get; set; }
 
         public void Press(TabletReference tablet, IDeviceReport report)
         {
@@ -35,6 +39,7 @@ namespace VoiDPlugins.Filter
             IsRelative = (RelativeMode == "Relative");
 
 
+            CurrentScale = Scale;
             SetPosition = true;
         }
 
@@ -51,9 +56,6 @@ namespace VoiDPlugins.Filter
         public event Action<IDeviceReport>? Emit;
 
         private readonly HPETDeltaStopwatch _stopwatch = new HPETDeltaStopwatch();
-
-        [SliderProperty("Precision Multiplier", 0.0f, 10f, 0.3f), DefaultPropertyValue(0.3f)]
-        public float Scale { get; set; }
 
         [SliderProperty("Timeout", 100f, 1000f, 1f), DefaultPropertyValue(50), Unit("ms")]
         [ToolTip("Time period after which the position is reset in relative mode.")]
@@ -92,7 +94,7 @@ namespace VoiDPlugins.Filter
                 if (PrecisionControlBinding.IsActive)
                 {
                     var relativeTo = PrecisionControlBinding.IsRelative ? NewZero : PrecisionControlBinding.StartingPoint;
-                    var delta = (report.Position - relativeTo) * Scale;
+                    var delta = (report.Position - relativeTo) * PrecisionControlBinding.CurrentScale;
                     report.Position = PrecisionControlBinding.StartingPoint + delta;
                 }
 

--- a/src/Filter/PrecisionControl/PrecisionControl.cs
+++ b/src/Filter/PrecisionControl/PrecisionControl.cs
@@ -20,10 +20,13 @@ namespace VoiDPlugins.Filter
         public static string[] ValidModes => new[] { "Toggle", "Hold" };
         public static string[] ValidRelativeModes => new[] { "Absolute", "Relative" };
 
-        [Property("Mode"), PropertyValidated(nameof(ValidModes)), DefaultPropertyValue("Toggle")]
+        [Property("Activation Mode"), PropertyValidated(nameof(ValidModes)), DefaultPropertyValue("Toggle")]
+        [ToolTip("Whether to toggle the precision mode or only activate while the button is held.")]
         public string? Mode { set; get; }
 
-        [Property("Relative Mode"), PropertyValidated(nameof(ValidRelativeModes)), DefaultPropertyValue("Absolute")]
+        [Property("Output Mode"), PropertyValidated(nameof(ValidRelativeModes)), DefaultPropertyValue("Absolute")]
+        [ToolTip("Whether to emulate the relative output mode or stick to absolute mode. "
+        + "In relative mode lifting the pen completely of the tablet and putting it down somewhere else does not change the position.")]
         public string? RelativeMode { set; get; }
 
         [SliderProperty("Precision Multiplier", 0.0f, 10f, 0.3f), DefaultPropertyValue(0.3f)]

--- a/src/Filter/PrecisionControl/PrecisionControl.cs
+++ b/src/Filter/PrecisionControl/PrecisionControl.cs
@@ -20,10 +20,10 @@ namespace VoiDPlugins.Filter
         public static string[] ValidModes => new[] { "Toggle", "Hold" };
         public static string[] ValidRelativeModes => new[] { "Absolute", "Relative" };
 
-        [Property("Mode"), PropertyValidated(nameof(ValidModes))]
+        [Property("Mode"), PropertyValidated(nameof(ValidModes)), DefaultPropertyValue("Toggle")]
         public string? Mode { set; get; }
 
-        [Property("Relative Mode"), PropertyValidated(nameof(ValidRelativeModes))]
+        [Property("Relative Mode"), PropertyValidated(nameof(ValidRelativeModes)), DefaultPropertyValue("Absolute")]
         public string? RelativeMode { set; get; }
 
         [SliderProperty("Precision Multiplier", 0.0f, 10f, 0.3f), DefaultPropertyValue(0.3f)]


### PR DESCRIPTION
This implements an emulation of the "Relative" output method when the increased precision mode is enabled. When binding the precision mode one can choose whether the absolute (hitherto implemented) or relative mode is used.

I found this supremely useful when writing notes with xournalpp as I would often hit the edge of the tablet fairly soon when precision mode was activated. Now, I can just lift the pen and continue on the top left corner :).

Hopefully my little "hack" is now polished enough for upstreaming.

I also made the precision multiplier configurable per-binding so that one can have multiple precision levels to choose from.

Cheers,
Valentin